### PR TITLE
Modify pbpbb extension for reactions

### DIFF
--- a/styles/prosilver/template/event/reactions.html
+++ b/styles/prosilver/template/event/reactions.html
@@ -14,7 +14,7 @@
         </span>
         <!-- END post_reactions -->
         <!-- Bouton pour palette - SEULEMENT pour les utilisateurs connectés -->
-        <span class="reaction-more" title="Ajouter une réaction">+</span>
+        <span class="reaction-more" title="Ajouter une réaction" data-tooltip="Cliquer pour rechercher un emoji"></span>
     </div>
 </div>
 <!-- ELSEIF S_REACTIONS_ENABLED and not S_IS_BOT and not S_USER_LOGGED_IN -->

--- a/styles/prosilver/template/event/viewtopic_body_postrow_content_after.html
+++ b/styles/prosilver/template/event/viewtopic_body_postrow_content_after.html
@@ -15,18 +15,7 @@
         <!-- END postrow.post_reactions -->
         
         <!-- Bouton pour palette avec recherche - SEULEMENT pour les utilisateurs connectés -->
-        <span class="reaction-more" title="Ajouter une réaction" data-tooltip="Cliquer pour rechercher un emoji">+</span>
-        
-        <!-- IF postrow.list_reactions|length > 0 -->
-            <span class="reaction-who" title="Qui a réagi ?" onclick="toggle_visible('lst_{postrow.POST_ID}')">?</span>
-            <div class="list-who" id="lst_{postrow.POST_ID}" style="display:none;">
-                <ul>
-                <!-- BEGIN postrow.list_reactions -->
-                    <li>{postrow.list_reactions.EMOJI} {postrow.list_reactions.NOM}</li>
-                <!-- END postrow.list_reactions -->
-                </ul>
-            </div>
-        <!-- ENDIF -->
+        <span class="reaction-more" title="Ajouter une réaction" data-tooltip="Cliquer pour rechercher un emoji"></span>
     </div>
 </div>
 
@@ -45,17 +34,6 @@
             </span>
             <!-- ENDIF -->
         <!-- END postrow.post_reactions -->
-        
-        <!-- IF postrow.list_reactions|length > 0 -->
-            <span class="reaction-who" title="Qui a réagi ?" onclick="toggle_visible('lst_{postrow.POST_ID}')">?</span>
-            <div class="list-who" id="lst_{postrow.POST_ID}" style="display:none;">
-                <ul>
-                <!-- BEGIN postrow.list_reactions -->
-                    <li>{postrow.list_reactions.EMOJI} {postrow.list_reactions.NOM}</li>
-                <!-- END postrow.list_reactions -->
-                </ul>
-            </div>
-        <!-- ENDIF -->
     </div>
 </div>
 <!-- ENDIF -->

--- a/styles/prosilver/template/js/reactions.js
+++ b/styles/prosilver/template/js/reactions.js
@@ -28,6 +28,13 @@ function toggle_visible(id) {
         document.querySelectorAll('.post-reactions .reaction:not(.reaction-readonly)').forEach(reaction => {
             reaction.removeEventListener('click', handleReactionClick);
             reaction.addEventListener('click', handleReactionClick);
+            
+            // Attacher le tooltip pour les réactions existantes
+            const postId = getPostIdFromReaction(reaction);
+            const emoji = reaction.getAttribute('data-emoji');
+            if (postId && emoji) {
+                setupReactionTooltip(reaction, postId, emoji);
+            }
         });
     }
 

--- a/styles/prosilver/theme/reactions.css
+++ b/styles/prosilver/theme/reactions.css
@@ -14,30 +14,59 @@
     gap: 6px;
 }
 
-/* CORRECTION MAJEURE : Bouton "+" fixe à gauche selon cahier des charges */
+/* CORRECTION MAJEURE : Bouton "+" transformé en pouce bleu */
 .reaction-more {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background: #f8f9fa;
-    border: 1px dashed #d1d1d1;
+    background: #e3f2fd; /* Bleu clair */
+    border: 1px solid #2196f3; /* Bordure bleue */
     border-radius: 15px;
     padding: 4px 8px;
     cursor: pointer;
-    font-size: 16px;
-    font-weight: bold;
-    color: #6c757d;
+    font-size: 18px;
+    color: #1976d2;
     transition: all 0.2s ease;
     min-width: 32px;
     height: 28px;
-    order: -1; /* CORRECTION : Force le bouton + en première position à gauche */
+    order: -1; /* CORRECTION : Force le bouton en première position à gauche */
     margin-right: 8px; /* Espacement avec les réactions */
+    position: relative;
+}
+
+/* Remplacer le texte par l'emoji pouce bleu */
+.reaction-more::before {
+    content: '👍'; /* Pouce bleu emoji */
+    font-size: 16px;
 }
 
 .reaction-more:hover {
-    background: #e9ecef;
-    color: #495057;
-    border-color: #adb5bd;
+    background: #bbdefb;
+    border-color: #1976d2;
+    transform: scale(1.05);
+}
+
+/* Tooltip au survol du bouton de réaction */
+.reaction-more::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #333;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s;
+    margin-bottom: 5px;
+}
+
+.reaction-more:hover::after {
+    opacity: 1;
 }
 
 .reaction-who {
@@ -292,57 +321,25 @@
         border-radius: 12px;
     }
     
-    .reaction-more {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        background: #e3f2fd; /* Bleu clair */
-        border: 1px solid #2196f3; /* Bleu */
-        border-radius: 15px;
-        padding: 4px 8px;
-        cursor: pointer;
-        font-size: 18px;
-        color: #1976d2;
-        transition: all 0.2s ease;
+    /* Pas de redéfinition nécessaire pour mobile - le style principal s'applique */
+    
+    .reaction-picker {
+        max-width: 280px;
+        left: 0 !important;
+        right: auto !important;
+    }
+    
+    .reaction-picker .reaction {
         min-width: 32px;
-        height: 28px;
-        order: -1;
-        margin-right: 8px;
-        position: relative;
-    }
-
-    .reaction-more::before {
-        content: '👍'; /* Pouce bleu emoji */
+        height: 32px;
         font-size: 16px;
+        padding: 6px;
     }
     
-    .reaction-more:hover {
-        background: #bbdefb;
-        border-color: #1976d2;
-        transform: scale(1.05);
+    /* CORRECTION : Scrollbar encore plus grosse sur mobile selon cahier des charges */
+    .emoji-picker::-webkit-scrollbar {
+        width: 16px; /* Encore plus large sur mobile */
     }
-    
-    /* Tooltip au survol du bouton de réaction */
-.reaction-more::after {
-    content: attr(data-tooltip);
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    background: #333;
-    color: white;
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: 11px;
-    white-space: nowrap;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s;
-    margin-bottom: 5px;
-}
-
-.reaction-more:hover::after {
-    opacity: 1;
 }
 
 /* SUPPRESSION DU BOUTON ? */
@@ -384,24 +381,6 @@
 .reaction-user-tooltip .reaction-user-link:not(:last-child)::after {
     content: ', ';
     color: #666;
-}
-    .reaction-picker {
-        max-width: 280px;
-        left: 0 !important;
-        right: auto !important;
-    }
-    
-    .reaction-picker .reaction {
-        min-width: 32px;
-        height: 32px;
-        font-size: 16px;
-        padding: 6px;
-    }
-    
-    /* CORRECTION : Scrollbar encore plus grosse sur mobile selon cahier des charges */
-    .emoji-picker::-webkit-scrollbar {
-        width: 16px; /* Encore plus large sur mobile */
-    }
 }
 
 /* Animation pour l'apparition des nouvelles réactions */


### PR DESCRIPTION
Convert the 'Add reaction' button to a blue thumbs-up emoji, remove the 'who reacted' button, and add hover tooltips to reaction emojis displaying reactors with profile links.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8345d85-64dc-4e3f-92d5-44e9019091f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8345d85-64dc-4e3f-92d5-44e9019091f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

