### PR TITLE
Modify pbpbb extension for reactions

### DIFF
--- a/styles/prosilver/template/event/reactions.html
+++ b/styles/prosilver/template/event/reactions.html
@@ -14,7 +14,7 @@
         </span>
         <!-- END post_reactions -->
         <!-- Bouton pour palette - SEULEMENT pour les utilisateurs connectés -->
-        <span class="reaction-more" title="Ajouter une réaction">+</span>
+        <span class="reaction-more" title="Ajouter une réaction">👍</span>
     </div>
 </div>
 <!-- ELSEIF S_REACTIONS_ENABLED and not S_IS_BOT and not S_USER_LOGGED_IN -->

--- a/styles/prosilver/template/event/viewtopic_body_postrow_content_after.html
+++ b/styles/prosilver/template/event/viewtopic_body_postrow_content_after.html
@@ -15,18 +15,7 @@
         <!-- END postrow.post_reactions -->
         
         <!-- Bouton pour palette avec recherche - SEULEMENT pour les utilisateurs connectés -->
-        <span class="reaction-more" title="Ajouter une réaction" data-tooltip="Cliquer pour rechercher un emoji">+</span>
-        
-        <!-- IF postrow.list_reactions|length > 0 -->
-            <span class="reaction-who" title="Qui a réagi ?" onclick="toggle_visible('lst_{postrow.POST_ID}')">?</span>
-            <div class="list-who" id="lst_{postrow.POST_ID}" style="display:none;">
-                <ul>
-                <!-- BEGIN postrow.list_reactions -->
-                    <li>{postrow.list_reactions.EMOJI} {postrow.list_reactions.NOM}</li>
-                <!-- END postrow.list_reactions -->
-                </ul>
-            </div>
-        <!-- ENDIF -->
+        <span class="reaction-more" title="Ajouter une réaction" data-tooltip="Cliquer pour rechercher un emoji">👍</span>
     </div>
 </div>
 
@@ -46,16 +35,7 @@
             <!-- ENDIF -->
         <!-- END postrow.post_reactions -->
         
-        <!-- IF postrow.list_reactions|length > 0 -->
-            <span class="reaction-who" title="Qui a réagi ?" onclick="toggle_visible('lst_{postrow.POST_ID}')">?</span>
-            <div class="list-who" id="lst_{postrow.POST_ID}" style="display:none;">
-                <ul>
-                <!-- BEGIN postrow.list_reactions -->
-                    <li>{postrow.list_reactions.EMOJI} {postrow.list_reactions.NOM}</li>
-                <!-- END postrow.list_reactions -->
-                </ul>
-            </div>
-        <!-- ENDIF -->
+        
     </div>
 </div>
 <!-- ENDIF -->

--- a/styles/prosilver/template/js/reactions.js
+++ b/styles/prosilver/template/js/reactions.js
@@ -22,6 +22,7 @@ function toggle_visible(id) {
         attachReactionEvents();
         attachMoreButtonEvents();
         document.addEventListener('click', closeAllPickers);
+        attachTooltipsToExistingReactions();
     }
 
     function attachReactionEvents() {
@@ -35,6 +36,18 @@ function toggle_visible(id) {
         document.querySelectorAll('.reaction-more').forEach(button => {
             button.removeEventListener('click', handleMoreButtonClick);
             button.addEventListener('click', handleMoreButtonClick);
+        });
+    }
+
+    function attachTooltipsToExistingReactions() {
+        document.querySelectorAll('.post-reactions-container').forEach(container => {
+            const postId = container.getAttribute('data-post-id');
+            if (!postId) return;
+            container.querySelectorAll('.post-reactions .reaction').forEach(reaction => {
+                const emoji = reaction.getAttribute('data-emoji');
+                if (!emoji) return;
+                setupReactionTooltip(reaction, postId, emoji);
+            });
         });
     }
 

--- a/styles/prosilver/theme/reactions.css
+++ b/styles/prosilver/theme/reactions.css
@@ -19,25 +19,26 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background: #f8f9fa;
-    border: 1px dashed #d1d1d1;
+    background: #e3f2fd;
+    border: 1px solid #2196f3;
     border-radius: 15px;
     padding: 4px 8px;
     cursor: pointer;
     font-size: 16px;
     font-weight: bold;
-    color: #6c757d;
+    color: #1976d2;
     transition: all 0.2s ease;
     min-width: 32px;
     height: 28px;
-    order: -1; /* CORRECTION : Force le bouton + en première position à gauche */
+    order: -1; /* Bouton à gauche */
     margin-right: 8px; /* Espacement avec les réactions */
 }
 
 .reaction-more:hover {
-    background: #e9ecef;
-    color: #495057;
-    border-color: #adb5bd;
+    background: #bbdefb;
+    color: #0d47a1;
+    border-color: #1976d2;
+    transform: scale(1.05);
 }
 
 .reaction-who {
@@ -291,65 +292,9 @@
         font-size: 13px;
         border-radius: 12px;
     }
-    
-    .reaction-more {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        background: #e3f2fd; /* Bleu clair */
-        border: 1px solid #2196f3; /* Bleu */
-        border-radius: 15px;
-        padding: 4px 8px;
-        cursor: pointer;
-        font-size: 18px;
-        color: #1976d2;
-        transition: all 0.2s ease;
-        min-width: 32px;
-        height: 28px;
-        order: -1;
-        margin-right: 8px;
-        position: relative;
-    }
 
-    .reaction-more::before {
-        content: '👍'; /* Pouce bleu emoji */
-        font-size: 16px;
-    }
-    
-    .reaction-more:hover {
-        background: #bbdefb;
-        border-color: #1976d2;
-        transform: scale(1.05);
-    }
-    
-    /* Tooltip au survol du bouton de réaction */
-.reaction-more::after {
-    content: attr(data-tooltip);
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    background: #333;
-    color: white;
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: 11px;
-    white-space: nowrap;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s;
-    margin-bottom: 5px;
-}
-
-.reaction-more:hover::after {
-    opacity: 1;
-}
-
-/* SUPPRESSION DU BOUTON ? */
-.reaction-who {
-    display: none !important;
-}
-
+/* SUPPRESSION DU BOUTON ? et de la liste associée */
+.reaction-who,
 .list-who {
     display: none !important;
 }


### PR DESCRIPTION
Convert '+' to '👍', remove '?' icon, and add user list tooltips on reaction hover with profile links.

This implements user-requested visual and interactive enhancements for the reaction system. The AJAX controller was updated to allow `get_users` for guests, ensuring the new tooltip functionality is available to all users without requiring login or CSRF for this read-only action.

---
<a href="https://cursor.com/background-agent?bcId=bc-6823aeab-960a-4c3f-9463-cad3cbbbb2fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6823aeab-960a-4c3f-9463-cad3cbbbb2fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

